### PR TITLE
build scripts: target docker repository configurable

### DIFF
--- a/api/cmd/kubeletdnat-controller/Makefile
+++ b/api/cmd/kubeletdnat-controller/Makefile
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DOCKER_REPO="quay.io/kubermatic"
+
 build:
 	CGO_ENABLED=0 go build -o ./_build/kubeletdnat-controller .
 
 docker: build
-	docker build -t quay.io/kubermatic/kubeletdnat-controller:$(TAG) .
+	docker build -t $(DOCKER_REPO)/kubeletdnat-controller:$(TAG) .
 
 .PHONY: build docker

--- a/api/cmd/nodeport-proxy/Makefile
+++ b/api/cmd/nodeport-proxy/Makefile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DOCKER_REPO="quay.io/kubermatic"
+
 default: test build
 
 lb-updater:
@@ -26,7 +28,7 @@ clean:
 	rm -f envoy-manager lb-updater
 
 docker: build
-	docker build -t quay.io/kubermatic/nodeport-proxy:$(TAG) .
+	docker build -t $(DOCKER_REPO)/nodeport-proxy:$(TAG) .
 
 test:
 	go test ./...

--- a/api/cmd/user-ssh-keys-agent/Makefile
+++ b/api/cmd/user-ssh-keys-agent/Makefile
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DOCKER_REPO="quay.io/kubermatic"
+
 build:
 	CGO_ENABLED=0 go build -o user-ssh-keys-agent
 
 docker: build
-	docker build -t quay.io/kubermatic/user-ssh-keys-agent:$(TAG) .
+	docker build -t $(DOCKER_REPO)/user-ssh-keys-agent:$(TAG) .
 
 .PHONY: build docker


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <olaf.klischat@gmail.com>

**What this PR does / why we need it**:

This adapts the build scripts that create docker images (`api/hack/push_image.sh` as well as a few Makefiles for smaller subprojects) so that the target docker repository to tag and push to is changeable from the standard quay.io/kubermatic (which is still the default, so this should be 100% backward compatible).

This enables people who don't have push permissions to quay.io/kubermatic to use the build scripts in the first place, as they can now push all the built images to their own repository.

Sample usage:

```
docker login ...
DOCKER_REPO=myrepo api/hack/push_image.sh myreleasetag
```

Builds and pushes images `myrepo/{kubermatic-ee,nodeport-proxy,kubeletdnat-controller,addons,openshift-addons,user-ssh-keys-agent,etcd-launcher-v33,etcd-launcher-v34,api}:myreleasetag`.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
build scripts: target docker repository configurable
```
